### PR TITLE
handle more eval commands used by SLIME in emacs

### DIFF
--- a/swank.rkt
+++ b/swank.rkt
@@ -67,6 +67,15 @@
                [(list 'swank:listener-eval code) 
                 `(:return (:ok (:values ,(evaluate to-repl from-repl code))) ,continuation)]
                
+               [(list 'swank:eval-and-grab-output code)
+                `(:return (:ok (,(evaluate to-repl from-repl code) "")) ,continuation)]
+
+               [(list (or 'swank:interactive-eval 'swank:pprint-eval) code)
+                `(:return (:ok ,(evaluate to-repl from-repl code)) ,continuation)]
+
+               [(list 'swank:interactive-eval-region code)
+                `(:return (:ok (:values ,(evaluate to-repl from-repl code))) ,continuation)]
+
                [(list 'swank:simple-completions pattern _) 
                 `(:return (:ok ,(list (code-complete pattern) pattern)) ,continuation)]
                


### PR DESCRIPTION
The Emacs SLIME implementation uses several variations of eval
for different purposes. These include slime-pprint-eval-region,
slime-interactive-eval, slime-eval-region, and several others.

The swank commands used by these eval functions include:
- swank:eval-and-grab-output
- swank:interactive-eval
- swank:pprint-eval
- swank:interactive-eval-region

I have implemented enough of each of these to satisfy SLIME
but they aren't full-featured.

swank:pprint-eval does not actually pretty print. It could
be implemented with racket's pretty-format function if an
s-expression form can be read from the repl instead of a string.
